### PR TITLE
Fix `Queries` type export leaking into js build outputs

### DIFF
--- a/src/renderStream/syncQueries.ts
+++ b/src/renderStream/syncQueries.ts
@@ -1,6 +1,6 @@
 import {queries} from '@testing-library/dom'
 
-export {Queries} from '@testing-library/dom'
+export type {Queries} from '@testing-library/dom'
 
 type OriginalQueries = typeof queries
 


### PR DESCRIPTION
In `vitest` it was causing this error:

```bash
SyntaxError: Named export 'Queries' not found. The requested module '@testing-library/dom' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@testing-library/dom';
const { Queries } = pkg;
```

For some reason the `Queries` type export ended up in js outputs.