### PR TITLE
fix: Make props optional in `rerender` function returned from `renderHookToSnapshotStream`

### DIFF
--- a/src/__tests__/renderHookToSnapshotStream.test.tsx
+++ b/src/__tests__/renderHookToSnapshotStream.test.tsx
@@ -3,7 +3,10 @@
 import {EventEmitter} from 'node:events'
 import {scheduler} from 'node:timers/promises'
 import {test, expect} from '@jest/globals'
-import {renderHookToSnapshotStream} from '@testing-library/react-render-stream'
+import {
+  renderHookToSnapshotStream,
+  SnapshotStream,
+} from '@testing-library/react-render-stream'
 import * as React from 'react'
 
 const testEvents = new EventEmitter<{
@@ -70,5 +73,40 @@ test.each<[type: string, initialValue: unknown, ...nextValues: unknown[]]>([
   expect(await takeSnapshot()).toBe(initialValue)
   for (const nextValue of nextValues) {
     expect(await takeSnapshot()).toBe(nextValue)
+  }
+})
+
+test.skip('type test: render function without an argument -> no argument required for `rerender`', async () => {
+  {
+    // prop type has nothing to infer on - defaults to `void`
+    const stream = await renderHookToSnapshotStream(() => {})
+    const _test1: SnapshotStream<void, void> = stream
+    // @ts-expect-error should not be assignable
+    const _test2: SnapshotStream<void, string> = stream
+    await stream.rerender()
+    // @ts-expect-error invalid argument
+    await stream.rerender('foo')
+  }
+  {
+    // prop type is implicitly set via the render function argument
+    const stream = await renderHookToSnapshotStream((_arg1: string) => {})
+    // @ts-expect-error should not be assignable
+    const _test1: SnapshotStream<void, void> = stream
+    const _test2: SnapshotStream<void, string> = stream
+    // @ts-expect-error missing argument
+    await stream.rerender()
+    await stream.rerender('foo')
+  }
+  {
+    // prop type is implicitly set via the initialProps argument
+    const stream = await renderHookToSnapshotStream(() => {}, {
+      initialProps: 'initial',
+    })
+    // @ts-expect-error should not be assignable
+    const _test1: SnapshotStream<void, void> = stream
+    const _test2: SnapshotStream<void, string> = stream
+    // @ts-expect-error missing argument
+    await stream.rerender()
+    await stream.rerender('foo')
   }
 })

--- a/src/__tests__/renderHookToSnapshotStream.test.tsx
+++ b/src/__tests__/renderHookToSnapshotStream.test.tsx
@@ -109,4 +109,14 @@ test.skip('type test: render function without an argument -> no argument require
     await stream.rerender()
     await stream.rerender('foo')
   }
+  {
+    // argument is optional
+    const stream = await renderHookToSnapshotStream((_arg1?: string) => {})
+
+    const _test1: SnapshotStream<void, void> = stream
+    const _test2: SnapshotStream<void, string> = stream
+    const _test3: SnapshotStream<void, string | undefined> = stream
+    await stream.rerender()
+    await stream.rerender('foo')
+  }
 })

--- a/src/renderHookToSnapshotStream.tsx
+++ b/src/renderHookToSnapshotStream.tsx
@@ -41,9 +41,19 @@ export interface SnapshotStream<Snapshot, Props> extends Assertable {
    * Does not advance the render iterator.
    */
   waitForNextSnapshot(options?: NextRenderOptions): Promise<Snapshot>
-  rerender: (rerenderCallbackProps: Props) => Promise<void>
+  rerender: (rerenderCallbackProps: VoidOptionalArg<Props>) => Promise<void>
   unmount: () => void
 }
+
+/**
+ * if `Arg` can be `undefined`, replace it with `void` to make type represent an optional argument in a function argument position
+ */
+type VoidOptionalArg<Arg> = Arg extends any // distribute members of a potential `Props` union
+  ? undefined extends Arg
+    ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      void
+    : Arg
+  : Arg
 
 export async function renderHookToSnapshotStream<ReturnValue, Props = void>(
   renderCallback: (props: Props) => ReturnValue,

--- a/src/renderHookToSnapshotStream.tsx
+++ b/src/renderHookToSnapshotStream.tsx
@@ -41,7 +41,7 @@ export interface SnapshotStream<Snapshot, Props> extends Assertable {
    * Does not advance the render iterator.
    */
   waitForNextSnapshot(options?: NextRenderOptions): Promise<Snapshot>
-  rerender: (rerenderCallbackProps: Props) => Promise<void>
+  rerender: (rerenderCallbackProps?: Props) => Promise<void>
   unmount: () => void
 }
 
@@ -51,17 +51,17 @@ export async function renderHookToSnapshotStream<ReturnValue, Props>(
 ): Promise<SnapshotStream<ReturnValue, Props>> {
   const {render, ...stream} = createRenderStream<{value: ReturnValue}, never>()
 
-  const HookComponent: React.FC<{arg: Props}> = props => {
-    stream.replaceSnapshot({value: renderCallback(props.arg)})
+  const HookComponent: React.FC<{arg: Props | undefined}> = props => {
+    stream.replaceSnapshot({value: renderCallback(props.arg!)})
     return null
   }
 
   const {rerender: baseRerender, unmount} = await render(
-    <HookComponent arg={initialProps!} />,
+    <HookComponent arg={initialProps} />,
     renderOptions,
   )
 
-  function rerender(rerenderCallbackProps: Props) {
+  function rerender(rerenderCallbackProps?: Props) {
     return baseRerender(<HookComponent arg={rerenderCallbackProps} />)
   }
 

--- a/src/renderHookToSnapshotStream.tsx
+++ b/src/renderHookToSnapshotStream.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-invalid-void-type */
 import {type RenderHookOptions} from '@testing-library/react/pure.js'
 import React from 'rehackt'
 import {createRenderStream} from './renderStream/createRenderStream.js'
@@ -41,27 +42,27 @@ export interface SnapshotStream<Snapshot, Props> extends Assertable {
    * Does not advance the render iterator.
    */
   waitForNextSnapshot(options?: NextRenderOptions): Promise<Snapshot>
-  rerender: (rerenderCallbackProps?: Props) => Promise<void>
+  rerender: (rerenderCallbackProps: Props) => Promise<void>
   unmount: () => void
 }
 
-export async function renderHookToSnapshotStream<ReturnValue, Props>(
+export async function renderHookToSnapshotStream<ReturnValue, Props = void>(
   renderCallback: (props: Props) => ReturnValue,
   {initialProps, ...renderOptions}: RenderHookOptions<Props> = {},
 ): Promise<SnapshotStream<ReturnValue, Props>> {
   const {render, ...stream} = createRenderStream<{value: ReturnValue}, never>()
 
-  const HookComponent: React.FC<{arg: Props | undefined}> = props => {
-    stream.replaceSnapshot({value: renderCallback(props.arg!)})
+  const HookComponent: React.FC<{arg: Props}> = props => {
+    stream.replaceSnapshot({value: renderCallback(props.arg)})
     return null
   }
 
   const {rerender: baseRerender, unmount} = await render(
-    <HookComponent arg={initialProps} />,
+    <HookComponent arg={initialProps!} />,
     renderOptions,
   )
 
-  function rerender(rerenderCallbackProps?: Props) {
+  function rerender(rerenderCallbackProps: Props) {
     return baseRerender(<HookComponent arg={rerenderCallbackProps} />)
   }
 

--- a/src/renderHookToSnapshotStream.tsx
+++ b/src/renderHookToSnapshotStream.tsx
@@ -71,8 +71,9 @@ export async function renderHookToSnapshotStream<ReturnValue, Props = void>(
     renderOptions,
   )
 
-  function rerender(rerenderCallbackProps: Props) {
-    return baseRerender(<HookComponent arg={rerenderCallbackProps} />)
+  function rerender(rerenderCallbackProps: VoidOptionalArg<Props>) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    return baseRerender(<HookComponent arg={rerenderCallbackProps as any} />)
   }
 
   return {

--- a/src/renderHookToSnapshotStream.tsx
+++ b/src/renderHookToSnapshotStream.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-invalid-void-type */
 import {type RenderHookOptions} from '@testing-library/react/pure.js'
 import React from 'rehackt'
 import {createRenderStream} from './renderStream/createRenderStream.js'


### PR DESCRIPTION
Fixes #13 

Makes the `props` argument optional in the `rerender` function returned from `renderHookToSnapshotStream`. This aligns it with RTL's [`rerender` function](https://github.com/testing-library/react-testing-library/blob/85ac2534a59abd38880011e77da4bb8c716eba84/types/index.d.ts#L159) returned from `renderHook`.
